### PR TITLE
fixed --version

### DIFF
--- a/bin/pear.js
+++ b/bin/pear.js
@@ -21,6 +21,14 @@ const argc = argv._.length
 
 process.argv.splice(1, argc, ...argv._)
 
+if (argv.v) {
+  const pkg = require('../package.json')
+
+  console.log(`v${pkg.version}`)
+
+  process.exit()
+}
+
 if (argv.h || argc === 0) {
   console.log(`
 🍐.js
@@ -31,14 +39,6 @@ Usage:
   `.trim())
 
   process.exit(argv.h || argc > 0 ? 0 : 1)
-}
-
-if (argv.v) {
-  const pkg = require('../package.json')
-
-  console.log(`v${pkg.version}`)
-
-  process.exit()
 }
 
 if (argv.m) {


### PR DESCRIPTION
--version is a boolean flag that shows the package.json version of pearjs. Since the help checks `if (argv.h || argc === 0)` , and exists the process after, the version flag didnt have any effect. This PR fixes the issue.


