### PR TITLE
add pear_run_begin and pear_run_tick

### DIFF
--- a/include/pear.h
+++ b/include/pear.h
@@ -33,6 +33,12 @@ int
 pear_run (pear_t *pear, const char *filename, const uv_buf_t *source);
 
 int
+pear_run_begin (pear_t *pear, const char *filename, const uv_buf_t *source);
+
+int
+pear_run_tick (pear_t *pear);
+
+int
 pear_exit (pear_t *pear, int exit_code);
 
 int

--- a/src/pear.c
+++ b/src/pear.c
@@ -105,6 +105,18 @@ pear_run (pear_t *pear, const char *filename, const uv_buf_t *source) {
 }
 
 int
+pear_run_begin (pear_t *pear, const char *filename, const uv_buf_t *source) {
+  return pear_runtime_run(&pear->runtime, filename, source);
+}
+
+int
+pear_run_tick (pear_t *pear) {
+  uv_run(pear->runtime.loop, UV_RUN_ONCE);
+
+  return 0;
+}
+
+int
 pear_exit (pear_t *pear, int exit_code) {
   if (pear->exited) return -1;
   pear->exited = true;


### PR DESCRIPTION
IMO sometimes embedders could need a more fine grained control of the event loop. Sometimes one needs to do some async job in the same uv loop's thread. My common approach is having a loop where I call `uv_run` with `UV_RUN_ONCE` while the uv loop is not done and a control bool is true; set it to false (usually from another thread with an async handler) to make it exit from the loop, do the async task and when done just re run the loop. With these 2 simple methods we gain more control to achieve that without leaving 🍐 .