### PR TITLE
disable addon normalisation as it breaks loading multiple majors

### DIFF
--- a/src/builtins/process/addon.js
+++ b/src/builtins/process/addon.js
@@ -1,11 +1,7 @@
 /* global bare */
 
-const path = require('../path')
-
 module.exports = exports = function addon (specifier) {
   if (typeof specifier !== 'string') throw new TypeError('dirname must be a string')
-
-  specifier = normalize(specifier)
 
   if (exports.cache[specifier]) return exports.cache[specifier]
 
@@ -19,15 +15,5 @@ exports.cache = Object.create(null)
 exports.resolve = function resolve (specifier) {
   if (typeof specifier !== 'string') throw new TypeError('dirname must be a string')
 
-  specifier = normalize(specifier)
-
   return bare.resolveAddon(specifier)
-}
-
-function normalize (specifier) {
-  const i = specifier.indexOf(path.join('/', 'node_modules'))
-
-  if (i >= 0) specifier = path.join(process.cwd(), specifier.slice(i))
-
-  return specifier
 }


### PR DESCRIPTION
Can understand the reasoning for the normalisation, but this gets problematic really fast. Unless we know of any real-world showstoppers, I'd like to revert this part.

Some issues.

1. Loading multiple major versions of the same native module breaks it they get normalised to the first one that is loaded.
2. `cd`'ing into `node_modules` and `node index.js` breaks native modules as they attempt to normalise based on cwd
3. When normalised, the js isn't normalised so the js might call init functions multiple times any

I think we should let the package managers dedup for us instead, or potentially support a opt-in flag for dedup in case the module author wants it. Let me know what you think :)