### PR TITLE
Remove cooperative termination from JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,17 +111,17 @@ If the process is exited explicitly, such as by calling `Bare.exit()` or as the 
 
 #### `Bare.on('exit', code)`
 
-Emitted just before the process or current thread terminates. Additional work scheduled from an `exit` event listener will be given a chance to run after which the process will terminate. If the process is forcefully terminated from an `exit` event listener, the remaining listeners will not run.
-
-> [!IMPORTANT]  
-> Only cleanup work may be scheduled from an `exit` event listener. All I/O, including timers, will be closed on `exit` and can therefore not be used.
+Emitted before the process or current thread terminates. Additional work must not be scheduled from an `exit` event listener. If the process is forcefully terminated from an `exit` event listener, the remaining listeners will not run.
 
 #### `Bare.on('teardown')`
 
-Emitted after the process or current thread has terminated and just before the JavaScript environment is torn down. Additional work must not be scheduled from a `teardown` event listener. Bare itself will register `teardown` event listeners to join dangling threads and unload native addons.
+Emitted after the process or current thread has terminated and before the JavaScript environment is torn down. Additional work must not be scheduled from a `teardown` event listener. Bare itself will register `teardown` event listeners to join dangling threads and unload native addons.
 
-> [!IMPORTANT]  
-> `teardown` listeners should generally be prepended to have the listeners run in last in, first out order:
+> [!IMPORTANT]
+>
+> ##### Teardown ordering
+>
+> `teardown` listeners **SHOULD** be prepended to have the listeners run in last in, first out order:
 >
 > ```js
 > Bare.prependListener('teardown', () => { ... })

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -883,7 +883,7 @@ bare_runtime_setup(uv_loop_t *loop, bare_process_t *process, bare_runtime_t *run
   { \
     uv_async_t *handle = &runtime->signals.signal; \
     handle->data = (void *) runtime; \
-    err = uv_async_init(runtime->loop, handle, bare_runtime_on_suspend_signal); \
+    err = uv_async_init(runtime->loop, handle, bare_runtime_on_##signal##_signal); \
     assert(err == 0); \
     uv_unref((uv_handle_t *) handle); \
   }


### PR DESCRIPTION
Cooperative termination will only be supported from C as it suffers from reentrancy bugs that cannot be fixed in practice when implemented from JavaScript.