### PR TITLE
Run the platform loop on a background thread

### DIFF
--- a/bin/bare.c
+++ b/bin/bare.c
@@ -81,13 +81,13 @@ main(int argc, char *argv[]) {
   err = uv_loop_close(loop);
   assert(err == 0);
 
-  err = log_close();
-  assert(err == 0);
-
   err = uv_async_send(&bare__platform_shutdown);
   assert(err == 0);
 
   uv_thread_join(&thread);
+
+  err = log_close();
+  assert(err == 0);
 
   return exit_code;
 }

--- a/bin/bare.c
+++ b/bin/bare.c
@@ -22,10 +22,10 @@ bare__on_platform_thread(void *data) {
   err = uv_loop_init(&loop);
   assert(err == 0);
 
-  err = js_create_platform(&loop, NULL, &bare__platform);
+  err = uv_async_init(&loop, &bare__platform_shutdown, bare__on_platform_shutdown);
   assert(err == 0);
 
-  err = uv_async_init(&loop, &bare__platform_shutdown, bare__on_platform_shutdown);
+  err = js_create_platform(&loop, NULL, &bare__platform);
   assert(err == 0);
 
   uv_sem_post(&bare__platform_ready);

--- a/bin/bare.c
+++ b/bin/bare.c
@@ -63,6 +63,8 @@ main(int argc, char *argv[]) {
 
   uv_sem_wait(&bare__platform_ready);
 
+  uv_sem_destroy(&bare__platform_ready);
+
   bare_t *bare;
   err = bare_setup(loop, bare__platform, NULL, argc, (const char **) argv, NULL, &bare);
   assert(err == 0);


### PR DESCRIPTION
V8 apparently risks deadlocking if specific platform background tasks are drained on the main thread: https://issues.chromium.org/issues/374285493. The fix is wonderfully simple: Don't do that 😂 