### PR TITLE
List resolution candidates at `ADDON_NOT_FOUND` error

### DIFF
--- a/src/addon.js
+++ b/src/addon.js
@@ -161,6 +161,8 @@ module.exports = exports = class Addon {
 
     if (resolution) return protocol.postresolve(resolution, parentURL)
 
+    const candidates = []
+
     for (const resolution of resolve(
       resolved,
       parentURL,
@@ -174,6 +176,8 @@ module.exports = exports = class Addon {
       },
       readPackage
     )) {
+      candidates.push(resolution)
+
       switch (resolution.protocol) {
         case 'builtin:':
           return resolution
@@ -193,7 +197,8 @@ module.exports = exports = class Addon {
     }
 
     throw AddonError.ADDON_NOT_FOUND(
-      `Cannot find addon '${specifier}' imported from '${parentURL.href}'`
+      `Cannot find demon '${specifier}' imported from '${parentURL.href}'
+Failed attempts: ${candidates.map((candidate) => `\n- ${candidate.toString()}`)}`
     )
 
     function readPackage(packageURL) {

--- a/src/addon.js
+++ b/src/addon.js
@@ -196,10 +196,14 @@ module.exports = exports = class Addon {
       }
     }
 
-    throw AddonError.ADDON_NOT_FOUND(
-      `Cannot find demon '${specifier}' imported from '${parentURL.href}'
-Failed attempts: ${candidates.map((candidate) => `\n- ${candidate.toString()}`)}`
-    )
+    let message = `Cannot find addon '${specifier}' imported from '${parentURL.href}'`
+
+    if (candidates.length > 0) {
+      message += '\nAttempted:'
+      message += '\n' + candidates.map((url) => '- ' + url.href).join('\n')
+    }
+
+    throw AddonError.ADDON_NOT_FOUND(message)
 
     function readPackage(packageURL) {
       if (protocol.exists(packageURL, constants.types.JSON)) {


### PR DESCRIPTION
Error sample:

```
Uncaught AddonError: ADDON_NOT_FOUND: Cannot find demon '.' imported from 'file:///Users/y/Documents/holepunch/bare/test/fixtures/adon/'
Failed attempts: 
- file:///bare/test/fixtures/addon/prebuilds/darwin-arm64/addon@1.2.3.bare,
- file:///bare/test/fixtures/addon/prebuilds/darwin-arm64/addon@1.2.3.node,
- file:///bare/test/fixtures/addon/prebuilds/darwin-arm64/addon.bare
    at Addon.resolve (bare:/bare.js:5295:22)
    at file:///bare/test/addon-resolve.js:6:24
    at Module._evaluate (bare:/bare.bundle/node_modules/bare-module/index.js:220:7)
    at Module._transform (bare:/bare.bundle/node_modules/bare-module/index.js:128:12)
    at Module.load (bare:/bare.bundle/node_modules/bare-module/index.js:467:21)
    at Command._runner (bare:/bare.bundle/bin/bare.js:81:21)
    at runAsync (bare:/bare.bundle/node_modules/paparam/index.js:780:13)
    at Command.parse (bare:/bare.bundle/node_modules/paparam/index.js:233:26)
    at bare:/bare.bundle/bin/bare.js:93:6
    at Module._evaluate (bare:/bare.js:8092:7)
```