### PR TITLE
Expose libc variant for which Bare is compiled on Linux

### DIFF
--- a/include/bare/target.h
+++ b/include/bare/target.h
@@ -51,18 +51,46 @@
 
 #if defined(__APPLE__)
 #define BARE_SIMULATOR TARGET_OS_SIMULATOR
-#else
+#endif
+
+#ifndef BARE_SIMULATOR
 #define BARE_SIMULATOR 0
+#endif
+
+#if defined(__linux__)
+#if defined(__ANDROID__)
+#define BARE_LIBC_BIONIC 1
+#elif defined(__MUSL__)
+#define BARE_LIBC_MUSL 1
+#else
+#define BARE_LIBC_GNU 1
+#endif
+#endif
+
+#ifndef BARE_LIBC_GNU
+#define BARE_LIBC_GNU 0
+#endif
+
+#ifndef BARE_LIBC_BIONIC
+#define BARE_LIBC_BIONIC 0
+#endif
+
+#ifndef BARE_LIBC_MUSL
+#define BARE_LIBC_MUSL 0
 #endif
 
 #define BARE_TARGET_SYSTEM BARE_PLATFORM "-" BARE_ARCH
 
 #if BARE_SIMULATOR
-#define BARE_TARGET_SIMULATOR "-simulator"
+#define BARE_TARGET_ENVIRONMENT "-simulator"
+#elif BARE_LIBC_MUSL
+#define BARE_TARGET_ENVIRONMENT "-musl"
 #else
-#define BARE_TARGET_SIMULATOR
+#define BARE_TARGET_ENVIRONMENT
 #endif
 
-#define BARE_TARGET BARE_TARGET_SYSTEM BARE_TARGET_SIMULATOR
+#define BARE_TARGET BARE_TARGET_SYSTEM BARE_TARGET_ENVIRONMENT
+
+#define BARE_HOST BARE_TARGET
 
 #endif // BARE_TARGET_H

--- a/include/bare/target.h
+++ b/include/bare/target.h
@@ -58,10 +58,10 @@
 #endif
 
 #if defined(__linux__)
-#if defined(__ANDROID__)
-#define BARE_LIBC_BIONIC 1
-#elif defined(__MUSL__)
+#if defined(__MUSL__)
 #define BARE_LIBC_MUSL 1
+#elif defined(__ANDROID__)
+#define BARE_LIBC_BIONIC 1
 #else
 #define BARE_LIBC_GNU 1
 #endif

--- a/src/addon.js
+++ b/src/addon.js
@@ -65,7 +65,7 @@ module.exports = exports = class Addon {
   }
 
   static get host() {
-    return `${bare.platform}-${bare.arch}${bare.simulator ? '-simulator' : ''}`
+    return bare.host
   }
 
   static load(url, opts = {}) {

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -984,6 +984,7 @@ bare_runtime_setup(uv_loop_t *loop, bare_process_t *process, bare_runtime_t *run
 
   V("platform", BARE_PLATFORM);
   V("arch", BARE_ARCH);
+  V("host", BARE_HOST);
 #undef V
 
   js_value_t *simulator;


### PR DESCRIPTION
Relies on https://github.com/holepunchto/cmake-toolchains/commit/115abf95bb33923652ff77844d7f5435b6de3306 for detecting musl. With this, Bare gains first-class support for loading native addon prebuilds for musl as `Bare.Addon.host` will reflect that Bare itself was compiled for musl:

```console
$ bare -p Bare.Addon.host
linux-arm64-musl
```

There's no `-gnu` variant as that is still the implicit default for Linux just as `-bionic` is the implicit default for Android.