### PR TITLE
Enable multi-line string evaluation

### DIFF
--- a/bin/bare.js
+++ b/bin/bare.js
@@ -70,7 +70,7 @@ const bare = command(
     }
 
     if (flags.eval) {
-      return Module.load(parentURL, `(${flags.eval})`)
+      return Module.load(parentURL, flags.eval)
     }
 
     if (flags.print) {


### PR DESCRIPTION
That seems to be the only blocker to accept multi-line strings, like:

```sh
$ bare -e "console.log(1)
console.log(2)"

# 1 
# 2
```