### PR TITLE
Remove obsolete `teardown` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ If the process is exited explicitly, such as by calling `Bare.exit()` or as the 
 
 #### `Bare.on('exit', code)`
 
-Emitted before the process or current thread terminates. If the process is forcefully terminated from an `exit` event listener, the remaining listeners will not run.
+Emitted when the process or current thread exits. If the process is forcefully terminated from an `exit` event listener, the remaining listeners will not run.
 
 > [!CAUTION]
 > Additional work **MUST NOT** be scheduled from an `exit` event listener.

--- a/README.md
+++ b/README.md
@@ -130,20 +130,6 @@ If the process is exited explicitly, such as by calling `Bare.exit()` or as the 
 
 Emitted before the process or current thread terminates. Additional work must not be scheduled from an `exit` event listener. If the process is forcefully terminated from an `exit` event listener, the remaining listeners will not run.
 
-#### `Bare.on('teardown')`
-
-Emitted after the process or current thread has terminated and before the JavaScript environment is torn down. Additional work must not be scheduled from a `teardown` event listener.
-
-> [!IMPORTANT]
->
-> ##### Teardown ordering
->
-> `teardown` listeners **SHOULD** be prepended to have the listeners run in last in, first out order:
->
-> ```js
-> Bare.prependListener('teardown', () => { ... })
-> ```
-
 #### `Bare.on('suspend', linger)`
 
 Emitted when the process or current thread is suspended. Any in-progress or outstanding work, such as network activity or file system access, should be deferred, cancelled, or paused when the `suspend` event is emitted and no additional work should be scheduled. A `suspend` event listener may call `Bare.resume()` to cancel the suspension.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ If the process is exited explicitly, such as by calling `Bare.exit()` or as the 
 
 #### `Bare.on('exit', code)`
 
-Emitted before the process or current thread terminates. Additional work must not be scheduled from an `exit` event listener. If the process is forcefully terminated from an `exit` event listener, the remaining listeners will not run.
+Emitted before the process or current thread terminates. If the process is forcefully terminated from an `exit` event listener, the remaining listeners will not run.
+
+> [!CAUTION]
+> Additional work **MUST NOT** be scheduled from an `exit` event listener.
 
 #### `Bare.on('suspend', linger)`
 

--- a/include/bare.h
+++ b/include/bare.h
@@ -18,7 +18,6 @@ typedef struct bare_options_s bare_options_t;
 
 typedef void (*bare_before_exit_cb)(bare_t *, void *data);
 typedef void (*bare_exit_cb)(bare_t *, void *data);
-typedef void (*bare_teardown_cb)(bare_t *, void *data);
 typedef void (*bare_suspend_cb)(bare_t *, int linger, void *data);
 typedef void (*bare_wakeup_cb)(bare_t *, int deadline, void *data);
 typedef void (*bare_idle_cb)(bare_t *, void *data);
@@ -128,12 +127,6 @@ bare_on_before_exit(bare_t *bare, bare_before_exit_cb cb, void *data);
  */
 int
 bare_on_exit(bare_t *bare, bare_exit_cb cb, void *data);
-
-/**
- * Equivalent to `Bare.on('teardown', cb)`.
- */
-int
-bare_on_teardown(bare_t *bare, bare_teardown_cb cb, void *data);
 
 /**
  * Equivalent to `Bare.on('suspend', cb)`.

--- a/src/bare.c
+++ b/src/bare.c
@@ -49,7 +49,6 @@ bare_setup(uv_loop_t *loop, js_platform_t *platform, js_env_t **env, int argc, c
 
   process->callbacks.before_exit = NULL;
   process->callbacks.exit = NULL;
-  process->callbacks.teardown = NULL;
   process->callbacks.suspend = NULL;
   process->callbacks.wakeup = NULL;
   process->callbacks.idle = NULL;
@@ -186,14 +185,6 @@ int
 bare_on_exit(bare_t *bare, bare_exit_cb cb, void *data) {
   bare->process.callbacks.exit = cb;
   bare->process.callbacks.exit_data = data;
-
-  return 0;
-}
-
-int
-bare_on_teardown(bare_t *bare, bare_teardown_cb cb, void *data) {
-  bare->process.callbacks.teardown = cb;
-  bare->process.callbacks.teardown_data = data;
 
   return 0;
 }

--- a/src/bare.js
+++ b/src/bare.js
@@ -215,10 +215,6 @@ bare.onexit = function onexit() {
   exports.emit('exit', bare.exitCode)
 }
 
-bare.onteardown = function onteardown() {
-  exports.emit('teardown')
-}
-
 bare.onsuspend = function onsuspend(linger) {
   suspending = true
 

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -180,17 +180,6 @@ bare_runtime__on_teardown(bare_runtime_t *runtime, int *exit_code) {
   err = js_get_reference_value(env, runtime->exports, &exports);
   assert(err == 0);
 
-  js_value_t *fn;
-  err = js_get_named_property(env, exports, "onteardown", &fn);
-  assert(err == 0);
-
-  js_value_t *global;
-  err = js_get_global(env, &global);
-  assert(err == 0);
-
-  err = js_call_function(env, global, fn, 0, NULL, NULL);
-  (void) err;
-
   if (exit_code) {
     js_value_t *val;
     err = js_get_named_property(env, exports, "exitCode", &val);
@@ -202,8 +191,6 @@ bare_runtime__on_teardown(bare_runtime_t *runtime, int *exit_code) {
 
   err = js_close_handle_scope(env, scope);
   assert(err == 0);
-
-  bare_runtime__invoke_callback_if_main_thread(runtime, teardown);
 }
 
 static inline void

--- a/src/types.h
+++ b/src/types.h
@@ -69,9 +69,6 @@ struct bare_process_s {
     bare_exit_cb exit;
     void *exit_data;
 
-    bare_teardown_cb teardown;
-    void *teardown_data;
-
     bare_suspend_cb suspend;
     void *suspend_data;
 


### PR DESCRIPTION
All callers have migrated to the native teardown API introduced in https://github.com/holepunchto/libjs/pull/8.