### PR TITLE
Add Bare.getInheritedLowFd for systemd socket activation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,7 @@ target_link_libraries(
 )
 
 add_subdirectory(bin)
+add_subdirectory(examples)
 
 install(TARGETS bare_static bare_shared)
 

--- a/bin/bare.c
+++ b/bin/bare.c
@@ -1,7 +1,10 @@
 #include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <js.h>
 #include <log.h>
 #include <rlimit.h>
+#include "../src/runtime.h"
 #include <signal.h>
 #include <uv.h>
 
@@ -50,6 +53,8 @@ bare__on_platform_thread(void *data) {
 int
 main(int argc, char *argv[]) {
   int err;
+
+  bare__runtime_init_lowfd();
 
 #ifdef SIGPIPE
   signal(SIGPIPE, SIG_IGN);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(systemd-launcher systemd-launcher.c)
+
+install(TARGETS systemd-launcher DESTINATION bin)

--- a/examples/socket-app.js
+++ b/examples/socket-app.js
@@ -1,0 +1,24 @@
+const assert = require('bare-assert')
+const tcp = require('bare-tcp')
+
+const socket = Bare.getInheritedLowFd(3)
+assert(socket !== null, 'Failed to get inherited socket on fd 3')
+
+const server = new tcp.Server()
+
+const listener = new tcp.Socket({ fd: socket.fd })
+
+listener.on('connection', (conn) => {
+  conn.on('data', (buffer) => {
+    const message = buffer.toString().trim()
+
+    if (message === 'PING') {
+      console.log('Socket app received PING, sending PONG...')
+      conn.write('PONG\n')
+      conn.end()
+      Bare.exit()
+    }
+  })
+})
+
+console.log('Server started using inherited systemd socket.')

--- a/examples/systemd-launcher.c
+++ b/examples/systemd-launcher.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <assert.h>
+#include <string.h>
+
+int main (int argc, char *argv[]) {
+  int fds[2];
+  int err = socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+  assert(err == 0);
+
+  pid_t pid = fork();
+  assert(pid >= 0);
+
+  if (pid == 0) {
+
+    close(fds[0]);
+
+    err = dup2(fds[1], 3);
+    assert(err == 3);
+
+    close(fds[1]);
+
+    char *args[] = {
+      "./build/bin/bare",
+      "examples/socket-app.js",
+      NULL
+    };
+
+    execv(args[0], args);
+
+    perror("execv failed");
+    exit(1);
+
+  } else {
+
+    close(fds[1]);
+
+    printf("Launcher: Sending PING to the Bare app...\n");
+
+    err = write(fds[0], "PING\n", 5);
+    assert(err == 5);
+
+    char response[16];
+    err = read(fds[0], response, sizeof(response) - 1);
+    assert(err > 0);
+    response[err] = '\0';
+
+    printf("Launcher: Received response: %s", response);
+
+    assert(strcmp(response, "PONG\n") == 0);
+
+    printf("Launcher: Success! The Bare app responded correctly.\n");
+
+    close(fds[0]);
+    waitpid(pid, NULL, 0);
+  }
+
+  return 0;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,6 @@
       "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.4.0.tgz",
       "integrity": "sha512-KN2Clfo9Tm0+1bRJxTNqX5Z1skLX8XbvJBGePkCqeGJ1fjV/2VXFc8Eb7NXBU7TM+jlUo7e7sGG5posv+EnU6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "bare": ">=1.20.0"
       }
@@ -131,7 +130,6 @@
       "resolved": "https://registry.npmjs.org/bare-bundle/-/bare-bundle-1.9.0.tgz",
       "integrity": "sha512-gijOehBzoBD/hmoMK12QOw33uhR0ssU5Tys7pxjRcdLH+u0OVa57VIGqyaNxl9qBrehX8N+bhIQ+vvI6Y0hJ9g==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-buffer": "*",
         "bare-url": "*"
@@ -657,7 +655,6 @@
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.0.tgz",
       "integrity": "sha512-c+RCqMSZbkz97Mw1LWR0gcOqwK82oyYKfLoHJ8k13ybi1+I80ffdDzUy0TdAburdrR/kI0/VuN8YgEnJqX+Nyw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -1292,7 +1289,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/src/bare.js
+++ b/src/bare.js
@@ -53,6 +53,21 @@ class Bare extends EventEmitter {
     return bare.argv
   }
 
+  /**
+   * Get an inherited file descriptor.
+   *
+   * This is primarily used for systemd-style socket activation, where a parent
+   * process (like systemd) opens a socket and passes its file descriptor (fd)
+   * to the Bare process. This function allows the JavaScript application to
+   * retrieve that descriptor.
+   *
+   * The available fds are numbers between 3 and 9 (inclusive). Each fd can
+   * only be retrieved once. Subsequent calls for the same fd will return `null`.
+   */
+  get getInheritedLowFd () {
+    return (fd) => bare.getInheritedLowFd(fd)
+  }
+
   get pid() {
     return bare.pid
   }

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -21,4 +21,7 @@ bare_runtime_load(bare_runtime_t *runtime, const char *filename, bare_source_t s
 int
 bare_runtime_run(bare_runtime_t *runtime, uv_run_mode mode);
 
+void 
+bare__runtime_init_lowfd(void);
+
 #endif // BARE_RUNTIME_H

--- a/src/types.h
+++ b/src/types.h
@@ -63,6 +63,8 @@ struct bare_process_s {
   int argc;
   const char **argv;
 
+  unsigned int inherited_lowfds_mask;
+
   struct {
     bare_before_exit_cb before_exit;
     void *before_exit_data;


### PR DESCRIPTION
This PR introduces Bare.getInheritedLowFd(fd), an API to support systemd-style socket activation.

This function allows a Bare application to retrieve a low-numbered file descriptor (3-9) inherited from a parent process. This is the standard mechanism for socket activation, enabling on-demand service launching and improving integration with modern Linux init systems.

To demonstrate this feature, a new practical example has been added to the examples/ directory. 

