### PR TITLE
Only rely on public `bare-module` API

### DIFF
--- a/src/addon.js
+++ b/src/addon.js
@@ -4,11 +4,16 @@ const resolve = require('bare-addon-resolve')
 const { fileURLToPath } = require('bare-url')
 const { AddonError } = require('./errors')
 
+const host = bare.host
+const builtins = bare.getStaticAddons()
+
+const defaultConditions = ['bare', 'node', ...host.split('-')]
+const defaultCache = Object.create(null)
+
 module.exports = exports = class Addon {
   constructor(url) {
     this._url = url
     this._exports = {}
-    this._handle = null
 
     Object.preventExtensions(this)
   }
@@ -30,39 +35,31 @@ module.exports = exports = class Addon {
     }
   }
 
-  static _cache = Object.create(null)
-
-  static _builtins = bare.getStaticAddons()
-
   static get cache() {
-    return this._cache
+    return defaultCache
   }
 
   static get host() {
-    return bare.host
+    return host
   }
 
   static load(url, opts /* reserved */) {
-    const self = Addon
-
-    const cache = self._cache
-
-    let addon = cache[url.href] || null
+    let addon = defaultCache[url.href] || null
 
     if (addon !== null) return addon
 
-    addon = cache[url.href] = new Addon(url)
+    addon = defaultCache[url.href] = new Addon(url)
 
     try {
       switch (url.protocol) {
         case 'builtin:':
-          addon._handle = bare.loadStaticAddon(url.pathname)
+          bare.loadStaticAddon(addon, url.pathname)
           break
         case 'linked:':
-          addon._handle = bare.loadDynamicAddon(url.pathname)
+          bare.loadDynamicAddon(addon, url.pathname)
           break
         case 'file:':
-          addon._handle = bare.loadDynamicAddon(fileURLToPath(url))
+          bare.loadDynamicAddon(addon, fileURLToPath(url))
           break
         default:
           throw AddonError.UNSUPPORTED_PROTOCOL(
@@ -70,9 +67,9 @@ module.exports = exports = class Addon {
           )
       }
 
-      addon._exports = bare.initAddon(addon._handle, addon._exports)
+      addon._exports = bare.initAddon(addon, addon._exports)
     } catch (err) {
-      delete cache[url.href]
+      delete defaultCache[url.href]
 
       throw err
     }
@@ -83,8 +80,6 @@ module.exports = exports = class Addon {
   static resolve(specifier, parentURL, opts = {}) {
     const Module = require('bare-module')
 
-    const self = Addon
-
     if (typeof specifier !== 'string') {
       throw new TypeError(
         `Specifier must be a string. Received type ${typeof specifier} (${specifier})`
@@ -93,12 +88,10 @@ module.exports = exports = class Addon {
 
     const {
       referrer = null,
-      cache = referrer ? referrer._cache : Object.create(null),
-      protocol = referrer ? referrer._protocol : Module._protocol,
-      imports = referrer ? referrer._imports : null,
-      resolutions = referrer ? referrer._resolutions : null,
-      builtins = self._builtins,
-      conditions = referrer ? referrer._conditions : Module._conditions
+      protocol = referrer ? referrer.protocol : Module.protocol,
+      imports = referrer ? referrer.imports : null,
+      resolutions = referrer ? referrer.resolutions : null,
+      conditions = referrer ? referrer.conditions : defaultConditions
     } = opts
 
     const resolved = protocol.preresolve(specifier, parentURL)
@@ -115,10 +108,10 @@ module.exports = exports = class Addon {
       resolved,
       parentURL,
       {
-        conditions: ['addon', ...conditions],
-        host: self.host,
-        resolutions,
+        host,
         builtins,
+        resolutions,
+        conditions: ['addon', ...conditions],
         extensions: ['.bare', '.node'],
         engines: bare.versions
       },
@@ -154,7 +147,7 @@ module.exports = exports = class Addon {
 
     function readPackage(packageURL) {
       if (protocol.exists(packageURL, Module.constants.types.JSON)) {
-        return Module.load(packageURL, { protocol, cache })._exports
+        return Module.load(packageURL, { protocol, referrer }).exports
       }
 
       return null

--- a/src/bare.js
+++ b/src/bare.js
@@ -15,9 +15,9 @@ bare.addon = function addon(href) {
 
   addon = addons[href] = { exports: {} }
 
-  const handle = bare.loadStaticAddon(href.replace(/^builtin:/, ''))
+  bare.loadStaticAddon(addon, href.replace(/^builtin:/, ''))
 
-  addon.exports = bare.initAddon(handle, addon.exports)
+  addon.exports = bare.initAddon(addon, addon.exports)
 
   return addon.exports
 }

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -516,42 +516,25 @@ static js_value_t *
 bare_runtime__load_static_addon(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  js_escapable_handle_scope_t *scope;
-  err = js_open_escapable_handle_scope(env, &scope);
-  assert(err == 0);
-
   bare_runtime_t *runtime;
 
-  js_value_t *argv[1];
-  size_t argc = 1;
+  js_value_t *argv[2];
+  size_t argc = 2;
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, (void **) &runtime);
   assert(err == 0);
 
-  assert(argc == 1);
+  assert(argc == 2);
 
   utf8_t specifier[4096];
-  err = js_get_value_string_utf8(env, argv[0], specifier, 4096, NULL);
+  err = js_get_value_string_utf8(env, argv[1], specifier, 4096, NULL);
   assert(err == 0);
 
   bare_addon_t *node = bare_addon_load_static(runtime, (char *) specifier);
 
-  if (node == NULL) goto err;
+  if (node == NULL) return NULL;
 
-  js_value_t *handle;
-  err = js_create_external(runtime->env, node, NULL, NULL, &handle);
-  assert(err == 0);
-
-  err = js_escape_handle(env, scope, handle, &handle);
-  assert(err == 0);
-
-  err = js_close_escapable_handle_scope(env, scope);
-  assert(err == 0);
-
-  return handle;
-
-err:
-  err = js_close_escapable_handle_scope(env, scope);
+  err = js_wrap(env, argv[0], (void *) node, NULL, NULL, NULL);
   assert(err == 0);
 
   return NULL;
@@ -561,42 +544,25 @@ static js_value_t *
 bare_runtime__load_dynamic_addon(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  js_escapable_handle_scope_t *scope;
-  err = js_open_escapable_handle_scope(env, &scope);
-  assert(err == 0);
-
   bare_runtime_t *runtime;
 
-  js_value_t *argv[1];
-  size_t argc = 1;
+  js_value_t *argv[2];
+  size_t argc = 2;
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, (void **) &runtime);
   assert(err == 0);
 
-  assert(argc == 1);
+  assert(argc == 2);
 
   utf8_t specifier[4096];
-  err = js_get_value_string_utf8(env, argv[0], specifier, 4096, NULL);
+  err = js_get_value_string_utf8(env, argv[1], specifier, 4096, NULL);
   assert(err == 0);
 
   bare_addon_t *node = bare_addon_load_dynamic(runtime, (char *) specifier);
 
-  if (node == NULL) goto err;
+  if (node == NULL) return NULL;
 
-  js_value_t *handle;
-  err = js_create_external(runtime->env, node, NULL, NULL, &handle);
-  assert(err == 0);
-
-  err = js_escape_handle(env, scope, handle, &handle);
-  assert(err == 0);
-
-  err = js_close_escapable_handle_scope(env, scope);
-  assert(err == 0);
-
-  return handle;
-
-err:
-  err = js_close_escapable_handle_scope(env, scope);
+  err = js_wrap(env, argv[0], (void *) node, NULL, NULL, NULL);
   assert(err == 0);
 
   return NULL;
@@ -619,7 +585,7 @@ bare_runtime__init_addon(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 2);
 
   bare_addon_t *node;
-  err = js_get_value_external(env, argv[0], (void **) &node);
+  err = js_unwrap(env, argv[0], (void **) &node);
   assert(err == 0);
 
   js_value_t *exports = argv[1];
@@ -755,72 +721,55 @@ static js_value_t *
 bare_runtime__setup_thread(js_env_t *env, js_callback_info_t *info) {
   int err;
 
-  js_escapable_handle_scope_t *scope;
-  err = js_open_escapable_handle_scope(env, &scope);
-  assert(err == 0);
-
   bare_runtime_t *runtime;
 
-  size_t argc = 4;
-  js_value_t *argv[4];
+  size_t argc = 5;
+  js_value_t *argv[5];
 
   err = js_get_callback_info(env, info, &argc, argv, NULL, (void **) &runtime);
   assert(err == 0);
 
-  assert(argc == 4);
+  assert(argc == 5);
 
   utf8_t filename[4096];
-  err = js_get_value_string_utf8(env, argv[0], filename, 4096, NULL);
+  err = js_get_value_string_utf8(env, argv[1], filename, 4096, NULL);
   assert(err == 0);
 
   bare_source_t source = {bare_source_none};
   bool has_source;
 
-  err = js_is_sharedarraybuffer(env, argv[1], &has_source);
+  err = js_is_sharedarraybuffer(env, argv[2], &has_source);
   assert(err == 0);
 
   if (has_source) {
     source.type = bare_source_sharedarraybuffer;
 
-    err = js_get_sharedarraybuffer_backing_store(env, argv[1], &source.backing_store);
+    err = js_get_sharedarraybuffer_backing_store(env, argv[2], &source.backing_store);
     assert(err == 0);
   }
 
   bare_data_t data = {bare_data_none};
   bool has_data;
 
-  err = js_is_sharedarraybuffer(env, argv[2], &has_data);
+  err = js_is_sharedarraybuffer(env, argv[3], &has_data);
   assert(err == 0);
 
   if (has_data) {
     data.type = bare_data_sharedarraybuffer;
 
-    err = js_get_sharedarraybuffer_backing_store(env, argv[2], &data.backing_store);
+    err = js_get_sharedarraybuffer_backing_store(env, argv[3], &data.backing_store);
     assert(err == 0);
   }
 
   uint32_t stack_size;
-  err = js_get_value_uint32(env, argv[3], &stack_size);
+  err = js_get_value_uint32(env, argv[4], &stack_size);
   assert(err == 0);
 
   bare_thread_t *thread;
   err = bare_thread_create(runtime, (char *) filename, source, data, stack_size, &thread);
-  if (err < 0) goto err;
+  if (err < 0) return NULL;
 
-  js_value_t *result;
-  err = js_create_external(env, (void *) thread, NULL, NULL, &result);
-  assert(err == 0);
-
-  err = js_escape_handle(env, scope, result, &result);
-  assert(err == 0);
-
-  err = js_close_escapable_handle_scope(env, scope);
-  assert(err == 0);
-
-  return result;
-
-err:
-  err = js_close_escapable_handle_scope(env, scope);
+  err = js_wrap(env, argv[0], (void *) thread, NULL, NULL, NULL);
   assert(err == 0);
 
   return NULL;
@@ -845,7 +794,7 @@ bare_runtime__join_thread(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 1);
 
   bare_thread_t *thread;
-  err = js_get_value_external(env, argv[0], (void **) &thread);
+  err = js_unwrap(env, argv[0], (void **) &thread);
   assert(err == 0);
 
   bare_thread_join(runtime, thread);
@@ -875,7 +824,7 @@ bare_runtime__suspend_thread(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 2);
 
   bare_thread_t *thread;
-  err = js_get_value_external(env, argv[0], (void **) &thread);
+  err = js_unwrap(env, argv[0], (void **) &thread);
   assert(err == 0);
 
   int32_t linger;
@@ -910,7 +859,7 @@ bare_runtime__wakeup_thread(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 2);
 
   bare_thread_t *thread;
-  err = js_get_value_external(env, argv[0], (void **) &thread);
+  err = js_unwrap(env, argv[0], (void **) &thread);
   assert(err == 0);
 
   int32_t deadline;
@@ -945,7 +894,7 @@ bare_runtime__resume_thread(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 1);
 
   bare_thread_t *thread;
-  err = js_get_value_external(env, argv[0], (void **) &thread);
+  err = js_unwrap(env, argv[0], (void **) &thread);
   assert(err == 0);
 
   err = bare_thread_resume(thread);
@@ -976,7 +925,7 @@ bare_runtime__terminate_thread(js_env_t *env, js_callback_info_t *info) {
   assert(argc == 1);
 
   bare_thread_t *thread;
-  err = js_get_value_external(env, argv[0], (void **) &thread);
+  err = js_unwrap(env, argv[0], (void **) &thread);
   assert(err == 0);
 
   err = bare_thread_terminate(thread);

--- a/src/thread.js
+++ b/src/thread.js
@@ -58,39 +58,43 @@ module.exports = exports = class Thread {
       structuredClone.encode(state, serialized)
     }
 
-    this._handle = bare.setupThread(filename, source, data, stackSize)
+    this._joined = false
+
+    bare.setupThread(this, filename, source, data, stackSize)
   }
 
   get joined() {
-    return this._handle === null
+    return this._joined
   }
 
   join() {
-    if (this._handle) bare.joinThread(this._handle)
+    if (this._joined) return
 
-    this._handle = null
+    this._joined = true
+
+    bare.joinThread(this)
   }
 
   suspend(linger = 0) {
     if (linger <= 0) linger = 0
     else linger = linger & 0xffffffff
 
-    if (this._handle) bare.suspendThread(this._handle, linger)
+    if (!this._joined) bare.suspendThread(this, linger)
   }
 
   wakeup(deadline = 0) {
     if (deadline <= 0) deadline = 0
     else deadline = deadline & 0xffffffff
 
-    if (this._handle) bare.wakeupThread(this._handle, deadline)
+    if (!this._joined) bare.wakeupThread(this, deadline)
   }
 
   resume() {
-    if (this._handle) bare.resumeThread(this._handle)
+    if (!this._joined) bare.resumeThread(this)
   }
 
   terminate() {
-    if (this._handle) bare.terminateThread(this._handle)
+    if (!this._joined) bare.terminateThread(this)
   }
 
   [Symbol.for('bare.inspect')]() {

--- a/test/leaks.txt
+++ b/test/leaks.txt
@@ -3,6 +3,7 @@ leak:js_create_typed_function
 leak:js_create_external
 leak:js_create_module
 leak:js_create_synthetic_module
+leak:js_wrap
 
 leak:v8::internal::GCTracer::*
 


### PR DESCRIPTION
An upcoming `bare-module` refactor will rework most of the internal `Module` properties as a shared context object to reduce the overhead of each instance.