### PR TITLE
Escape the loaded module handle out of bare_runtime_load's scope

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -1355,8 +1355,8 @@ bare_runtime_load(bare_runtime_t *runtime, const char *filename, bare_source_t s
 
   js_env_t *env = runtime->env;
 
-  js_handle_scope_t *scope;
-  err = js_open_handle_scope(env, &scope);
+  js_escapable_handle_scope_t *scope;
+  err = js_open_escapable_handle_scope(env, &scope);
   assert(err == 0);
 
   js_value_t *exports;
@@ -1398,15 +1398,19 @@ bare_runtime_load(bare_runtime_t *runtime, const char *filename, bare_source_t s
   }
 
   err = js_call_function(env, global, load, 2, args, result);
-  (void) err;
 
-  err = js_close_handle_scope(env, scope);
+  if (err == 0 && result != NULL) {
+    err = js_escape_handle(env, scope, *result, result);
+    assert(err == 0);
+  }
+
+  err = js_close_escapable_handle_scope(env, scope);
   assert(err == 0);
 
   return 0;
 
 err:
-  err = js_close_handle_scope(env, scope);
+  err = js_close_escapable_handle_scope(env, scope);
   assert(err == 0);
 
   return -1;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -1355,9 +1355,15 @@ bare_runtime_load(bare_runtime_t *runtime, const char *filename, bare_source_t s
 
   js_env_t *env = runtime->env;
 
-  js_escapable_handle_scope_t *scope;
-  err = js_open_escapable_handle_scope(env, &scope);
-  assert(err == 0);
+  void *scope;
+
+  if (result) {
+    err = js_open_escapable_handle_scope(env, (js_escapable_handle_scope_t **) &scope);
+    assert(err == 0);
+  } else {
+    err = js_open_handle_scope(env, (js_handle_scope_t **) &scope);
+    assert(err == 0);
+  }
 
   js_value_t *exports;
   err = js_get_reference_value(env, runtime->exports, &exports);
@@ -1399,19 +1405,29 @@ bare_runtime_load(bare_runtime_t *runtime, const char *filename, bare_source_t s
 
   err = js_call_function(env, global, load, 2, args, result);
 
-  if (err == 0 && result != NULL) {
-    err = js_escape_handle(env, scope, *result, result);
+  if (result && err == 0) {
+    err = js_escape_handle(env, (js_escapable_handle_scope_t *) scope, *result, result);
     assert(err == 0);
   }
 
-  err = js_close_escapable_handle_scope(env, scope);
-  assert(err == 0);
+  if (result) {
+    err = js_close_escapable_handle_scope(env, (js_escapable_handle_scope_t *) scope);
+    assert(err == 0);
+  } else {
+    err = js_close_handle_scope(env, (js_handle_scope_t *) scope);
+    assert(err == 0);
+  }
 
   return 0;
 
 err:
-  err = js_close_escapable_handle_scope(env, scope);
-  assert(err == 0);
+  if (result) {
+    err = js_close_escapable_handle_scope(env, (js_escapable_handle_scope_t *) scope);
+    assert(err == 0);
+  } else {
+    err = js_close_handle_scope(env, (js_handle_scope_t *) scope);
+    assert(err == 0);
+  }
 
   return -1;
 }


### PR DESCRIPTION
building bare-kit with quickjs (libqjs) instead of v8 caused bare-kit issues on android
traced it to bare_runtime_load in src/runtime.c. it opens a handle scope, calls load() into *result, then closes the scope before returning but never escapes the result handle. so the value it hands back is living in a scope thats already closed. v8 keeps it alive but quickjs (and jsc) free it on scope close, leaving the caller with a dangling handle.
fix is to open an escapable scope and js_escape_handle the result before closing — same thing every other value-returning function in this file already does (load_static_addon etc), this one was just the odd one out. guarded on result != NULL since bare_thread calls it with NULL, and on err == 0 so a failed load() doesnt escape an unset handle.
no behaviour change on v8, fixes the loaded exports on quickjs/jsc.