### PR TITLE
Allow extending `Addon` instances

### DIFF
--- a/src/addon.js
+++ b/src/addon.js
@@ -14,8 +14,6 @@ module.exports = exports = class Addon {
   constructor(url) {
     this._url = url
     this._exports = {}
-
-    Object.preventExtensions(this)
   }
 
   get url() {


### PR DESCRIPTION
It breaks in engine bindings where `js_wrap()` is backed for normal properties.