### PR TITLE
Exclude the debug CRT for all non-debug configurations on win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,12 @@ if(BARE_PREBUILDS AND BARE_ENGINE MATCHES "github:holepunchto/libjs(#|@|$)")
         # The imported static library always links the release version of the
         # static CRT; explicitly tell MSVC to not link the release version for
         # debug builds and vice versa.
-        /NODEFAULTLIB:libcmt$<$<CONFIG:Release>:d>
+        #
+        # Keyed on Debug rather than Release so that it stays the complement of
+        # the /DEFAULTLIB above. Keying on Release excluded the release CRT from
+        # RelWithDebInfo and MinSizeRel, which link against it, leaving every CRT
+        # symbol undefined.
+        /NODEFAULTLIB:libcmt$<$<NOT:$<CONFIG:Debug>>:d>
     )
   else()
     target_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,7 @@ if(BARE_PREBUILDS AND BARE_ENGINE MATCHES "github:holepunchto/libjs(#|@|$)")
         # debug builds and vice versa.
         #
         # Keyed on Debug rather than Release so that it stays the complement of
-        # the /DEFAULTLIB above. Keying on Release excluded the release CRT from
-        # RelWithDebInfo and MinSizeRel, which link against it, leaving every CRT
-        # symbol undefined.
+        # the /DEFAULTLIB above.
         /NODEFAULTLIB:libcmt$<$<NOT:$<CONFIG:Debug>>:d>
     )
   else()


### PR DESCRIPTION
On win32, `RelWithDebInfo` and `MinSizeRel` can't link at all: every CRT symbol comes out undefined (`malloc`, `memset`, `_DllMainCRTStartup`, `__security_cookie`, `_fltused`, `__dyn_tls_init`).

The two `target_link_options` below are meant to be complements - the comment says "not link the release version for debug builds and vice versa" - but one keys on Debug and the other on Release, and with four configurations "not Release" isn't "Debug":

```cmake
/DEFAULTLIB:libcpmt$<$<CONFIG:Debug>:d>      # Debug -> libcpmtd, else libcpmt
/NODEFAULTLIB:libcmt$<$<CONFIG:Release>:d>   # Release -> libcmtd, else libcmt
```

So RelWithDebInfo and MinSizeRel select the release C++ library and then exclude the release CRT they link against. Keying both on Debug fixes it.

Verified on win32-arm64 by generating each configuration and reading the flags ninja gets:

| config | before | after |
| --- | --- | --- |
| Debug | `/NODEFAULTLIB:libcmt` | `/NODEFAULTLIB:libcmt` |
| Release | `/NODEFAULTLIB:libcmtd` | `/NODEFAULTLIB:libcmtd` |
| RelWithDebInfo | `/NODEFAULTLIB:libcmt` | `/NODEFAULTLIB:libcmtd` |
| MinSizeRel | `/NODEFAULTLIB:libcmt` | `/NODEFAULTLIB:libcmtd` |

Debug and Release are unchanged; only the two broken configurations move.

Found via bare-kit: its `publish.yml` builds with `--with-debug-symbols` (RelWithDebInfo), which no CI job had ever exercised on win32, so the first tagged release that included the new windows job failed to link. `integrate.yml` uses `--debug`, which is why tests stayed green.
