### PR TITLE
Guard the uncaught exception callback against re-entry from a rethrowing handler

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -41,8 +41,7 @@ bare_runtime__on_uncaught_exception(js_env_t *env, js_value_t *error, void *data
 
   bare_runtime_t *runtime = data;
 
-  // A rethrowing `uncaughtException` handler would otherwise re-enter this
-  // callback with no recursion bound.
+  // A rethrowing handler re-enters this callback with no recursion bound
   if (runtime->handling_uncaught_exception) abort();
 
   runtime->handling_uncaught_exception = true;

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -41,6 +41,12 @@ bare_runtime__on_uncaught_exception(js_env_t *env, js_value_t *error, void *data
 
   bare_runtime_t *runtime = data;
 
+  // A rethrowing `uncaughtException` handler would otherwise re-enter this
+  // callback with no recursion bound.
+  if (runtime->handling_uncaught_exception) abort();
+
+  runtime->handling_uncaught_exception = true;
+
   js_handle_scope_t *scope;
   err = js_open_handle_scope(env, &scope);
   assert(err == 0);
@@ -61,6 +67,8 @@ bare_runtime__on_uncaught_exception(js_env_t *env, js_value_t *error, void *data
 
   err = js_call_function(env, global, fn, 1, args, NULL);
   (void) err;
+
+  runtime->handling_uncaught_exception = false;
 
   err = js_close_handle_scope(env, scope);
   assert(err == 0);
@@ -1214,6 +1222,7 @@ bare_runtime_setup(uv_loop_t *loop, bare_process_t *process, bare_runtime_t *run
   assert(err == 0);
 
   runtime->state = bare_runtime_state_active;
+  runtime->handling_uncaught_exception = false;
   runtime->linger = 0;
   runtime->deadline = 0;
 

--- a/src/types.h
+++ b/src/types.h
@@ -40,6 +40,8 @@ struct bare_runtime_s {
 
   bare_runtime_state_t state;
 
+  bool handling_uncaught_exception;
+
   int linger;
   int deadline;
 


### PR DESCRIPTION
If an `uncaughtException` listener throws, the exception escapes back into libjs, whose `try_catch` at depth 0 re-invokes the uncaught-exception callback - `bare_runtime__on_uncaught_exception` then re-enters the throwing JS handler with no recursion bound. Each round adds native and JS frames until the thread's guard page kills the process (SIGSEGV/SIGTRAP on desktop, SIGBUS on iOS), so a buggy handler can never reach the default print-and-abort path.

This adds a per-runtime re-entrancy flag: a second synchronous entry aborts, turning unbounded native recursion into a deterministic `abort()`.

Repro (`bare repro.js`):

```js
Bare.on('uncaughtException', function (err) {
  throw new Error('handler failed: ' + err.message)
})

setTimeout(function () {
  throw new Error('boom')
}, 10)
```

Before: exit 133 (SIGTRAP, stack exhaustion). After: exit 134 (SIGABRT at the guard). A non-throwing listener still handles and the process continues; full test suite passes (63/63).

Co-authored-by note: prepared with Claude Code.