### PR TITLE
Don't read `resolutions` and `imports` from `module`

### DIFF
--- a/src/addon.js
+++ b/src/addon.js
@@ -92,11 +92,7 @@ module.exports = exports = class Addon {
       )
     }
 
-    const {
-      referrer = null,
-      protocol = referrer ? referrer.protocol : defaultProtocol,
-      resolutions = referrer ? referrer.resolutions : null
-    } = opts
+    const { referrer = null, protocol = referrer ? referrer.protocol : defaultProtocol } = opts
 
     const candidates = []
 
@@ -105,7 +101,7 @@ module.exports = exports = class Addon {
     for (const resolution of resolve(
       specifier,
       parentURL,
-      { host, builtins, resolutions, conditions, extensions, engines },
+      { host, builtins, conditions, extensions, engines },
       readPackage
     )) {
       candidates.push(resolution)

--- a/test/helpers/bundle.js
+++ b/test/helpers/bundle.js
@@ -2,7 +2,7 @@ const Bundle = require('bare-bundle')
 const traverse = require('bare-module-traverse')
 const { pathToFileURL } = require('bare-url')
 
-const { protocol, imports, resolutions } = module
+const { protocol } = module
 
 module.exports = function bundle(entry, callback = null) {
   if (typeof entry === 'string') entry = pathToFileURL(entry)
@@ -11,11 +11,7 @@ module.exports = function bundle(entry, callback = null) {
 
   const bundle = new Bundle()
 
-  for (const dependency of traverse(
-    entry,
-    { imports, resolutions, resolve: traverse.resolve.bare },
-    readModule
-  )) {
+  for (const dependency of traverse(entry, { resolve: traverse.resolve.bare }, readModule)) {
     bundle.write(dependency.url.href, dependency.source, {
       main: dependency.url.href === entry.href,
       imports: dependency.imports


### PR DESCRIPTION
These APIs are going away in `bare-module` v7 and were only an optimization for the now deprecated `Addon.resolve()` API.